### PR TITLE
Refresh README for current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # Eidos
 
-Eidos is a TypeScript toolkit for building creative-coding sketches with p5.js. It combines a lightweight geometry core, a Verlet-based physics engine, and rendering helpers so you can prototype interactive systems without re-implementing the basics every time.
+Eidos is a TypeScript toolkit for building creative-coding sketches with p5.js. It combines a lightweight geometry core, a Verlet-based physics engine inspired by [toxiclibsjs](https://github.com/hapticdata/toxiclibsjs), and rendering helpers so you can prototype interactive systems without re-implementing the basics every time.
 
-Eidos (εἶδος) refers to the generative form that emerges when people co-create within functional and organisational structures. The library borrows that idea by providing shared primitives—vectors, particles, forces, and drawing helpers—that teams can assemble into richer systems while keeping a common language for collaboration.
+Eidos (εἶδος) refers to Plato's form, an idea with a functional structure.
 
 ## Features
 
 ### Geometry primitives
+
 -   `Vec` for 2D vector math with both pure and mutating helpers.
 -   `Circle`, `Line`, and `Rect` types with distance and intersection utilities.
 
 ### Physics system
+
 -   `PhysicsEngine` orchestrates particles with configurable gravity, friction, drag, damping, repulsion, mouse interaction, and boundary bouncing.
 -   `Particle` implements Verlet integration with force accumulation, locking, and spring registration.
 -   Structural helpers including `Spring`, `SpringChain`, `ParticleEmitter`, and `ParticleSink`.
 -   Behavior interfaces (`AttractBehavior`, `BounceBehavior`, `DragBehavior`, `FrictionBehavior`, `GravityBehavior`, `GravitationBehavior`, `JitterBehavior`, `ConstantForceBehavior`) for layering additional forces.
 
 ### Graphics helpers
+
 -   `GFX` wraps a p5 instance and offers particle/spring rendering, vector arrows, polygons, curves, grids, and text helpers with overloads for both vectors and raw coordinates.
 
 ## Installation
@@ -41,32 +44,32 @@ import p5 from 'p5';
 import { PhysicsEngine, Particle, Vec, GFX } from 'eidos';
 
 new p5(sketch => {
-        let engine: PhysicsEngine;
-        let gfx: GFX;
-        let particle: Particle;
+	let engine: PhysicsEngine;
+	let gfx: GFX;
+	let particle: Particle;
 
-        sketch.setup = () => {
-                sketch.createCanvas(800, 600);
+	sketch.setup = () => {
+		sketch.createCanvas(800, 600);
 
-                engine = new PhysicsEngine(sketch.width, sketch.height);
-                engine.hasGravity = true;
-                engine.gravity.set(0, 0.3);
+		engine = new PhysicsEngine(sketch.width, sketch.height);
+		engine.hasGravity = true;
+		engine.gravity.set(0, 0.3);
 
-                particle = new Particle(new Vec(sketch.width / 2, 100));
-                engine.addParticle(particle);
+		particle = new Particle(new Vec(sketch.width / 2, 100));
+		engine.addParticle(particle);
 
-                gfx = new GFX(sketch);
-        };
+		gfx = new GFX(sketch);
+	};
 
-        sketch.draw = () => {
-                sketch.background(32);
+	sketch.draw = () => {
+		sketch.background(32);
 
-                engine.update();
+		engine.update();
 
-                sketch.stroke(255);
-                sketch.fill(255);
-                gfx.particle(particle, 12);
-        };
+		sketch.stroke(255);
+		sketch.fill(255);
+		gfx.particle(particle, 12);
+	};
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,396 +1,85 @@
 # Eidos
 
-A TypeScript geometry and physics library for p5.js, inspired by toxiclibs.js.
+Eidos is a TypeScript toolkit for building creative-coding sketches with p5.js. It combines a lightweight geometry core, a Verlet-based physics engine, and rendering helpers so you can prototype interactive systems without re-implementing the basics every time.
+
+Eidos (εἶδος) refers to the generative form that emerges when people co-create within functional and organisational structures. The library borrows that idea by providing shared primitives—vectors, particles, forces, and drawing helpers—that teams can assemble into richer systems while keeping a common language for collaboration.
+
+## Features
+
+### Geometry primitives
+-   `Vec` for 2D vector math with both pure and mutating helpers.
+-   `Circle`, `Line`, and `Rect` types with distance and intersection utilities.
+
+### Physics system
+-   `PhysicsEngine` orchestrates particles with configurable gravity, friction, drag, damping, repulsion, mouse interaction, and boundary bouncing.
+-   `Particle` implements Verlet integration with force accumulation, locking, and spring registration.
+-   Structural helpers including `Spring`, `SpringChain`, `ParticleEmitter`, and `ParticleSink`.
+-   Behavior interfaces (`AttractBehavior`, `BounceBehavior`, `DragBehavior`, `FrictionBehavior`, `GravityBehavior`, `GravitationBehavior`, `JitterBehavior`, `ConstantForceBehavior`) for layering additional forces.
+
+### Graphics helpers
+-   `GFX` wraps a p5 instance and offers particle/spring rendering, vector arrows, polygons, curves, grids, and text helpers with overloads for both vectors and raw coordinates.
 
 ## Installation
+
+To use Eidos in your own project:
+
+```bash
+npm install eidos p5
+```
+
+For local development inside this repository:
 
 ```bash
 npm install
 npm run build
 ```
 
-## Usage
-
-### Basic Setup
+## Quick start with p5.js
 
 ```typescript
 import p5 from 'p5';
-import Eidos from 'eidos';
-import { Particle } from 'eidos/physics';
+import { PhysicsEngine, Particle, Vec, GFX } from 'eidos';
 
 new p5(sketch => {
-	const physics = new Eidos.PhysicsEngine();
-	const gfx = new Eidos.GFX(sketch);
+        let engine: PhysicsEngine;
+        let gfx: GFX;
+        let particle: Particle;
 
-	sketch.setup = () => {
-		sketch.createCanvas(800, 600);
+        sketch.setup = () => {
+                sketch.createCanvas(800, 600);
 
-		// Add a particle
-		const p = physics.addParticle(new Particle(100, 100));
-	};
+                engine = new PhysicsEngine(sketch.width, sketch.height);
+                engine.hasGravity = true;
+                engine.gravity.set(0, 0.3);
 
-	sketch.draw = () => {
-		sketch.background(255);
+                particle = new Particle(new Vec(sketch.width / 2, 100));
+                engine.addParticle(particle);
 
-		// Update physics
-		physics.update();
+                gfx = new GFX(sketch);
+        };
 
-		// Draw particles
-		physics.particles.forEach(particle => {
-			gfx.particle(particle);
-		});
-	};
+        sketch.draw = () => {
+                sketch.background(32);
+
+                engine.update();
+
+                sketch.stroke(255);
+                sketch.fill(255);
+                gfx.particle(particle, 12);
+        };
 });
 ```
 
-## Core Components
+## Additional examples
 
-### Physics
+More focused sketches demonstrating emitters, chains, and behaviours live in the [`examples/`](examples) directory. Each example imports from the published entry points (`eidos`, `eidos/physics`, etc.) and can be adapted into your own tooling or bundler setup.
 
-#### Particle
+## Building the package
 
-Represents a point mass with position, velocity, and forces.
-
-```typescript
-const p = new Particle(x, y, mass);
-p.addForce(new Vec(10, 0));
-p.addVelocity(new Vec(1, 1));
-p.lock(); // Lock position
-p.unlock();
-```
-
-#### Spring
-
-Connects two particles with spring forces.
-
-```typescript
-const spring = new Spring(particleA, particleB, strength, restLength);
-physics.addSpring(spring);
-```
-
-#### AttractionBehavior
-
-Applies attraction/repulsion forces between particles.
-
-```typescript
-const attractor = new Particle(400, 300, 10);
-const attraction = new AttractionBehavior(attractor, radius, strength);
-physics.addBehavior(attraction);
-```
-
-#### PhysicsEngine
-
-Main engine that manages and updates all physics entities.
-
-```typescript
-const physics = new Eidos.PhysicsEngine();
-physics.setGravity(0, 0.5);
-physics.setDrag(0.01);
-physics.update();
-```
-
-### Geometry
-
-#### Vec
-
-2D vector with common vector operations.
-
-```typescript
-const v = new Vec(10, 20);
-v.add(new Vec(5, 5));
-v.normalize();
-v.scale(2);
-v.rotate(Math.PI / 4);
-```
-
-### Graphics
-
-#### GFX
-
-Helper class for rendering physics objects with p5.js.
-
-```typescript
-const gfx = new Eidos.GFX(sketch);
-gfx.particle(particle, size);
-gfx.spring(spring, showRestLength);
-gfx.line(vec1, vec);
-gfx.circle(center, radius);
-gfx.arrow(from, to);
-```
-
-## Development
+The build output is generated with [`tsup`](https://tsup.egoist.dev). Regenerate the distributable files after making changes:
 
 ```bash
-# Watch mode for development
-npm run dev
-
-# Build for production
 npm run build
 ```
 
-## API Reference
-
-### PhysicsEngine Methods
-
--   `addParticle(particle: Particle): Particle`
--   `removeParticle(particle: Particle): void`
--   `addSpring(spring: Spring): Spring`
--   `removeSpring(spring: Spring): void`
--   `addBehavior(behavior: AttractionBehavior): AttractionBehavior`
--   `removeBehavior(behavior: AttractionBehavior): void`
--   `setGravity(x: number, y: number): void`
--   `setDrag(drag: number): void`
--   `update(): void`
--   `clear(): void`
-
-### Vec Methods
-
--   `copy(): Vec`
--   `set(x: number, y: number): Vec`
--   `add(v: Vec): Vec`
--   `sub(v: Vec): Vec`
--   `scale(s: number): Vec`
--   `mult(s: number): Vec`
--   `div(s: number): Vec`
--   `magnitude(): number`
--   `magSquared(): number`
--   `normalize(): Vec`
--   `limit(max: number): Vec`
--   `distanceTo(v: Vec): number`
--   `dot(v: Vec): number`
--   `rotate(angle: number): Vec`
--   `lerp(v: Vec, t: number): Vec`
--   `constrain(min: Vec, max: Vec): Vec`
-
-### GFX Methods
-
--   `particle(p: Particle, size?: number): void`
--   `spring(s: Spring, showRestLength?: boolean): void`
--   `line(v1: Vec, v2: Vec): void`
--   `circle(center: Vec, radius: number): void`
--   `rect(topLeft: Vec, width: number, height: number): void`
--   `arrow(from: Vec, to: Vec, arrowSize?: number): void`
--   `vector(origin: Vec, vec: Vec, scale?: number): void`
-
-## Examples
-
-### Simple Gravity Simulation
-
-```typescript
-import p5 from 'p5';
-import Eidos from 'eidos';
-import { Particle } from 'eidos/physics';
-
-new p5(sketch => {
-	const physics = new Eidos.PhysicsEngine();
-	const gfx = new Eidos.GFX(sketch);
-
-	sketch.setup = () => {
-		sketch.createCanvas(800, 600);
-		physics.setGravity(0, 0.5);
-
-		// Create particles
-		for (let i = 0; i < 50; i++) {
-			const x = sketch.random(sketch.width);
-			const y = sketch.random(100);
-			physics.addParticle(new Particle(x, y));
-		}
-	};
-
-	sketch.draw = () => {
-		sketch.background(255);
-		physics.update();
-
-		// Bounce particles off bottom
-		physics.particles.forEach(p => {
-			if (p.position.y > sketch.height) {
-				p.position.y = sketch.height;
-				p.velocity.y *= -0.8;
-			}
-		});
-
-		sketch.fill(100, 150, 250);
-		sketch.noStroke();
-		physics.particles.forEach(p => gfx.particle(p, 8));
-	};
-});
-```
-
-### Cloth Simulation
-
-```typescript
-import p5 from 'p5';
-import Eidos from 'eidos';
-import { Particle, Spring } from 'eidos/physics';
-
-new p5(sketch => {
-	const physics = new Eidos.PhysicsEngine();
-	const gfx = new Eidos.GFX(sketch);
-	const cols = 20;
-	const rows = 15;
-	const spacing = 20;
-
-	sketch.setup = () => {
-		sketch.createCanvas(800, 600);
-		physics.setGravity(0, 0.3);
-
-		// Create grid of particles
-		const particles: Particle[][] = [];
-		for (let y = 0; y < rows; y++) {
-			particles[y] = [];
-			for (let x = 0; x < cols; x++) {
-				const p = new Particle(
-					200 + x * spacing,
-					50 + y * spacing,
-					0.5
-				);
-				particles[y][x] = p;
-				physics.addParticle(p);
-			}
-		}
-
-		// Lock top row
-		for (let x = 0; x < cols; x++) {
-			particles[0][x].lock();
-		}
-
-		// Create springs
-		for (let y = 0; y < rows; y++) {
-			for (let x = 0; x < cols; x++) {
-				// Horizontal springs
-				if (x < cols - 1) {
-					physics.addSpring(
-						new Spring(particles[y][x], particles[y][x + 1], 0.1)
-					);
-				}
-				// Vertical springs
-				if (y < rows - 1) {
-					physics.addSpring(
-						new Spring(particles[y][x], particles[y + 1][x], 0.1)
-					);
-				}
-			}
-		}
-	};
-
-	sketch.draw = () => {
-		sketch.background(255);
-		physics.update();
-
-		// Draw springs
-		sketch.stroke(150);
-		sketch.strokeWeight(1);
-		physics.springs.forEach(s => gfx.spring(s));
-
-		// Draw particles
-		sketch.fill(100, 150, 250);
-		sketch.noStroke();
-		physics.particles.forEach(p => gfx.particle(p, 4));
-	};
-
-	sketch.mousePressed = () => {
-		// Find nearest particle and pull it
-		let nearest: Particle | null = null;
-		let minDist = 50;
-
-		physics.particles.forEach(p => {
-			const d = p.position.distanceTo(
-				new Vec(sketch.mouseX, sketch.mouseY)
-			);
-			if (d < minDist) {
-				minDist = d;
-				nearest = p;
-			}
-		});
-
-		if (nearest) {
-			nearest.position.set(sketch.mouseX, sketch.mouseY);
-		}
-	};
-});
-```
-
-### Attraction/Repulsion
-
-```typescript
-import p5 from 'p5';
-import Eidos from 'eidos';
-import { Particle, AttractionBehavior } from 'eidos/physics';
-import { Vec } from 'eidos/geom';
-
-new p5(sketch => {
-	const physics = new Eidos.PhysicsEngine();
-	const gfx = new Eidos.GFX(sketch);
-	let mouseAttractor: Particle;
-	let attraction: AttractionBehavior;
-
-	sketch.setup = () => {
-		sketch.createCanvas(800, 600);
-		physics.setGravity(0, 0);
-
-		// Create particles with random velocities
-		for (let i = 0; i < 100; i++) {
-			const p = physics.addParticle(
-				new Particle(
-					sketch.random(sketch.width),
-					sketch.random(sketch.height)
-				)
-			);
-			p.velocity = Vec.random(2);
-		}
-
-		// Create mouse attractor
-		mouseAttractor = new Particle(sketch.width / 2, sketch.height / 2, 5);
-		mouseAttractor.lock();
-		physics.addParticle(mouseAttractor);
-
-		// Add attraction behavior
-		attraction = new AttractionBehavior(mouseAttractor, 200, 1, 30);
-		physics.addBehavior(attraction);
-	};
-
-	sketch.draw = () => {
-		sketch.background(255);
-
-		// Update mouse attractor position
-		mouseAttractor.position.set(sketch.mouseX, sketch.mouseY);
-
-		// Toggle attraction/repulsion with mouse button
-		attraction.strength = sketch.mouseIsPressed ? -2 : 1;
-
-		physics.update();
-
-		// Wrap particles around screen
-		physics.particles.forEach(p => {
-			if (p === mouseAttractor) return;
-
-			if (p.position.x < 0) p.position.x = sketch.width;
-			if (p.position.x > sketch.width) p.position.x = 0;
-			if (p.position.y < 0) p.position.y = sketch.height;
-			if (p.position.y > sketch.height) p.position.y = 0;
-		});
-
-		// Draw particles
-		sketch.fill(100, 150, 250, 150);
-		sketch.noStroke();
-		physics.particles.forEach(p => {
-			if (p !== mouseAttractor) {
-				gfx.particle(p, 6);
-			}
-		});
-
-		// Draw attractor
-		sketch.fill(250, 100, 100);
-		gfx.particle(mouseAttractor, 15);
-
-		// Draw attraction radius
-		sketch.noFill();
-		sketch.stroke(250, 100, 100, 50);
-		gfx.circle(mouseAttractor.position, attraction.radius);
-	};
-});
-```
-
-## License
-
-MIT
+This command produces CommonJS, ESM, and TypeScript declaration bundles inside `dist/` that align with the `package.json` exports map.


### PR DESCRIPTION
## Summary
- update the README overview to reflect the current geometry, physics, and graphics modules
- document installation options, quick-start usage with p5.js, and links to examples
- add context for the "Eidos" name as a collaborative creative toolkit

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e123609e148320a3e011f542a996e5